### PR TITLE
Change `NOTE_RENAME` to `NOTE_DELETE`

### DIFF
--- a/courses/01-advanced-async/022-excercise-real-wake.org
+++ b/courses/01-advanced-async/022-excercise-real-wake.org
@@ -16,7 +16,7 @@
 
   #+BEGIN_SRC rust
     let mut watcher = kqueue::Watcher::new()?;
-    watcher.add_filename(path, kqueue::EventFilter::EVFILT_VNODE, kqueue::FilterFlag::NOTE_RENAME)?;
+    watcher.add_filename(path, kqueue::EventFilter::EVFILT_VNODE, kqueue::FilterFlag::NOTE_DELETE)?;
   #+END_SRC
 
 * Alternatively


### PR DESCRIPTION
`RENAME` did not work for me, which kind of makes sense given the kqueue docs: `The file referenced by the descriptor was renamed.` 

`manifest` is never renamed, so this event never triggers. What seems to be triggered is `DELETE`.